### PR TITLE
delegate realtime meta data to seperate Class

### DIFF
--- a/application/src/main/java/org/opentripplanner/transit/model/timetable/RealTimeTripTimes.java
+++ b/application/src/main/java/org/opentripplanner/transit/model/timetable/RealTimeTripTimes.java
@@ -29,8 +29,6 @@ public final class RealTimeTripTimes implements TripTimes<RealTimeTripTimes> {
 
   private final int[] arrivalTimes;
   private final int[] departureTimes;
-  private final RealTimeState realTimeState;
-  private final StopRealTimeState[] stopRealTimeStates;
   private final BitSet extraCalls;
   private final BitSet hasArrived;
   private final BitSet hasDeparted;
@@ -39,22 +37,21 @@ public final class RealTimeTripTimes implements TripTimes<RealTimeTripTimes> {
   private final I18NString tripHeadsign;
 
   private final I18NString[] stopHeadsigns;
-  private final OccupancyStatus[] occupancyStatus;
   private final Accessibility wheelchairAccessibility;
+
+  private final TripRealTimeMetadata tripRealTimeMetadata;
 
   RealTimeTripTimes(RealTimeTripTimesBuilder builder) {
     scheduledTripTimes = builder.scheduledTripTimes();
     arrivalTimes = builder.arrivalTimes();
     departureTimes = builder.departureTimes();
-    realTimeState = builder.realTimeState();
-    stopRealTimeStates = builder.stopRealTimeStates();
     extraCalls = builder.extraCalls();
     tripHeadsign = builder.tripHeadsign();
     stopHeadsigns = builder.stopHeadsigns();
-    occupancyStatus = builder.occupancyStatus();
     wheelchairAccessibility = builder.wheelchairAccessibility();
     hasArrived = builder.hasArrived();
     hasDeparted = builder.hasDeparted();
+    tripRealTimeMetadata = builder.realTimeMetadataBuilder().build();
     validateNonIncreasingTimes();
   }
 
@@ -65,15 +62,13 @@ public final class RealTimeTripTimes implements TripTimes<RealTimeTripTimes> {
     this.scheduledTripTimes = scheduledTripTimes;
     this.arrivalTimes = original.arrivalTimes;
     this.departureTimes = original.departureTimes;
-    this.realTimeState = original.realTimeState;
-    this.stopRealTimeStates = original.stopRealTimeStates;
     this.extraCalls = original.extraCalls;
     this.tripHeadsign = original.tripHeadsign;
     this.stopHeadsigns = original.stopHeadsigns;
-    this.occupancyStatus = original.occupancyStatus;
     this.wheelchairAccessibility = original.wheelchairAccessibility;
     this.hasArrived = original.hasArrived;
     this.hasDeparted = original.hasDeparted;
+    this.tripRealTimeMetadata = original.tripRealTimeMetadata;
   }
 
   /**
@@ -86,15 +81,13 @@ public final class RealTimeTripTimes implements TripTimes<RealTimeTripTimes> {
       .build();
     this.arrivalTimes = IntUtils.shiftArray(timeShift, original.arrivalTimes);
     this.departureTimes = IntUtils.shiftArray(timeShift, original.departureTimes);
-    this.realTimeState = original.realTimeState;
-    this.stopRealTimeStates = original.stopRealTimeStates;
     this.extraCalls = original.extraCalls;
     this.tripHeadsign = original.tripHeadsign;
     this.stopHeadsigns = original.stopHeadsigns;
-    this.occupancyStatus = original.occupancyStatus;
     this.wheelchairAccessibility = original.wheelchairAccessibility;
     this.hasArrived = original.hasArrived;
     this.hasDeparted = original.hasDeparted;
+    this.tripRealTimeMetadata = original.tripRealTimeMetadata;
   }
 
   ScheduledTripTimes scheduledTripTimes() {
@@ -186,7 +179,7 @@ public final class RealTimeTripTimes implements TripTimes<RealTimeTripTimes> {
   }
 
   public boolean isCancelledStop(int stopPos) {
-    return isStopRealTimeStates(stopPos, StopRealTimeState.CANCELLED);
+    return tripRealTimeMetadata.hasStopRealTimeState(stopPos, StopRealTimeState.CANCELLED);
   }
 
   @Override
@@ -200,11 +193,14 @@ public final class RealTimeTripTimes implements TripTimes<RealTimeTripTimes> {
   }
 
   public boolean isNoDataStop(int stopPos) {
-    return isStopRealTimeStates(stopPos, StopRealTimeState.NO_DATA);
+    return tripRealTimeMetadata.hasStopRealTimeState(stopPos, StopRealTimeState.NO_DATA);
   }
 
   public boolean isPredictionInaccurate(int stopPos) {
-    return isStopRealTimeStates(stopPos, StopRealTimeState.INACCURATE_PREDICTIONS);
+    return tripRealTimeMetadata.hasStopRealTimeState(
+      stopPos,
+      StopRealTimeState.INACCURATE_PREDICTIONS
+    );
   }
 
   public boolean isExtraCall(int stopPos) {
@@ -213,8 +209,8 @@ public final class RealTimeTripTimes implements TripTimes<RealTimeTripTimes> {
 
   public boolean isRealTimeUpdated(int stopPos) {
     return (
-      realTimeState != RealTimeState.SCHEDULED &&
-      !isStopRealTimeStates(stopPos, StopRealTimeState.NO_DATA)
+      tripRealTimeMetadata.realTimeState() != RealTimeState.SCHEDULED &&
+      !tripRealTimeMetadata.hasStopRealTimeState(stopPos, StopRealTimeState.NO_DATA)
     );
   }
 
@@ -223,14 +219,12 @@ public final class RealTimeTripTimes implements TripTimes<RealTimeTripTimes> {
    */
   @Override
   public OccupancyStatus getOccupancyStatus(int stopPos) {
-    if (this.occupancyStatus == null) {
-      return OccupancyStatus.NO_DATA_AVAILABLE;
-    }
-    return this.occupancyStatus[stopPos];
+    return tripRealTimeMetadata.getOccupancyStatusForStop(stopPos);
   }
 
-  OccupancyStatus[] copyOccupancyStatus() {
-    return occupancyStatus.clone();
+  @Override
+  public TripRealTimeMetadata getRealTimeMetadata() {
+    return tripRealTimeMetadata;
   }
 
   @Override
@@ -245,7 +239,7 @@ public final class RealTimeTripTimes implements TripTimes<RealTimeTripTimes> {
 
   @Override
   public boolean isScheduled() {
-    return realTimeState == RealTimeState.SCHEDULED;
+    return tripRealTimeMetadata.realTimeState() == RealTimeState.SCHEDULED;
   }
 
   @Override
@@ -255,17 +249,17 @@ public final class RealTimeTripTimes implements TripTimes<RealTimeTripTimes> {
 
   @Override
   public boolean isCanceled() {
-    return realTimeState == RealTimeState.CANCELED;
+    return tripRealTimeMetadata.realTimeState() == RealTimeState.CANCELED;
   }
 
   @Override
   public boolean isDeleted() {
-    return realTimeState == RealTimeState.DELETED;
+    return tripRealTimeMetadata.realTimeState() == RealTimeState.DELETED;
   }
 
   @Override
   public RealTimeState getRealTimeState() {
-    return realTimeState;
+    return tripRealTimeMetadata.realTimeState();
   }
 
   /**
@@ -354,20 +348,6 @@ public final class RealTimeTripTimes implements TripTimes<RealTimeTripTimes> {
     return scheduledTripTimes.getTrip();
   }
 
-  StopRealTimeState[] copyStopRealTimeStates() {
-    return stopRealTimeStates.clone();
-  }
-
-  /**
-   * The real-time states for a given stops. If the state is DEFAULT for a stop,
-   * the {@link #getRealTimeState()} should determine the realtime state of the stop.
-   * <p>
-   * This is only for API-purposes (does not affect routing).
-   */
-  private boolean isStopRealTimeStates(int stopPos, StopRealTimeState state) {
-    return stopRealTimeStates != null && stopRealTimeStates[stopPos] == state;
-  }
-
   I18NString[] copyStopHeadsigns() {
     return stopHeadsigns.clone();
   }
@@ -385,11 +365,9 @@ public final class RealTimeTripTimes implements TripTimes<RealTimeTripTimes> {
       Objects.equals(scheduledTripTimes, that.scheduledTripTimes) &&
       Objects.deepEquals(arrivalTimes, that.arrivalTimes) &&
       Objects.deepEquals(departureTimes, that.departureTimes) &&
-      realTimeState == that.realTimeState &&
-      Objects.deepEquals(stopRealTimeStates, that.stopRealTimeStates) &&
       Objects.equals(tripHeadsign, that.tripHeadsign) &&
       Objects.deepEquals(stopHeadsigns, that.stopHeadsigns) &&
-      Objects.deepEquals(occupancyStatus, that.occupancyStatus) &&
+      Objects.deepEquals(tripRealTimeMetadata, that.tripRealTimeMetadata) &&
       wheelchairAccessibility == that.wheelchairAccessibility
     );
   }
@@ -400,12 +378,10 @@ public final class RealTimeTripTimes implements TripTimes<RealTimeTripTimes> {
       scheduledTripTimes,
       Arrays.hashCode(arrivalTimes),
       Arrays.hashCode(departureTimes),
-      realTimeState,
-      Arrays.hashCode(stopRealTimeStates),
       tripHeadsign,
       Arrays.hashCode(stopHeadsigns),
-      Arrays.hashCode(occupancyStatus),
-      wheelchairAccessibility
+      wheelchairAccessibility,
+      tripRealTimeMetadata
     );
   }
 }

--- a/application/src/main/java/org/opentripplanner/transit/model/timetable/RealTimeTripTimesBuilder.java
+++ b/application/src/main/java/org/opentripplanner/transit/model/timetable/RealTimeTripTimesBuilder.java
@@ -3,7 +3,6 @@ package org.opentripplanner.transit.model.timetable;
 import static org.opentripplanner.transit.model.timetable.TimetableValidationError.ErrorCode.MISSING_ARRIVAL_TIME;
 import static org.opentripplanner.transit.model.timetable.TimetableValidationError.ErrorCode.MISSING_DEPARTURE_TIME;
 
-import java.util.Arrays;
 import java.util.BitSet;
 import java.util.stream.IntStream;
 import javax.annotation.Nullable;
@@ -17,11 +16,6 @@ public class RealTimeTripTimesBuilder {
   private final Integer[] arrivalTimes;
   private final Integer[] departureTimes;
 
-  @Nullable
-  private RealTimeState realTimeState;
-
-  private final StopRealTimeState[] stopRealTimeStates;
-
   private final BitSet extraCalls;
   private final BitSet hasArrived;
   private final BitSet hasDeparted;
@@ -30,12 +24,11 @@ public class RealTimeTripTimesBuilder {
   private I18NString tripHeadsign;
 
   private final I18NString[] stopHeadsigns;
-  private final OccupancyStatus[] occupancyStatus;
 
   @Nullable
   private Accessibility wheelchairAccessibility;
 
-  private boolean updated;
+  private final TripRealTimeMetadata.TripRealTimeMetadataBuilder tripRealTimeMetadataBuilder;
 
   /**
    * This constructor takes a ScheduledTripTimes (not base TripTimes) to enforce creating a new
@@ -50,14 +43,11 @@ public class RealTimeTripTimesBuilder {
     var numStops = tripTimes.getNumStops();
     arrivalTimes = new Integer[numStops];
     departureTimes = new Integer[numStops];
-    stopRealTimeStates = new StopRealTimeState[numStops];
-    Arrays.fill(stopRealTimeStates, StopRealTimeState.DEFAULT);
     extraCalls = new BitSet(numStops);
     stopHeadsigns = new I18NString[numStops];
-    occupancyStatus = new OccupancyStatus[numStops];
-    Arrays.fill(occupancyStatus, OccupancyStatus.NO_DATA_AVAILABLE);
     hasArrived = new BitSet(numStops);
     hasDeparted = new BitSet(numStops);
+    tripRealTimeMetadataBuilder = TripRealTimeMetadata.builder(numStops);
   }
 
   /**
@@ -125,13 +115,11 @@ public class RealTimeTripTimesBuilder {
   }
 
   public RealTimeTripTimesBuilder withArrivalTime(int stop, int time) {
-    updated = true;
     arrivalTimes[stop] = time;
     return this;
   }
 
   public RealTimeTripTimesBuilder withArrivalDelay(int stop, int delay) {
-    updated = true;
     arrivalTimes[stop] = getScheduledArrivalTime(stop) + delay;
     return this;
   }
@@ -168,43 +156,13 @@ public class RealTimeTripTimesBuilder {
   }
 
   public RealTimeTripTimesBuilder withDepartureTime(int stop, int time) {
-    updated = true;
     departureTimes[stop] = time;
     return this;
   }
 
   public RealTimeTripTimesBuilder withDepartureDelay(int stop, int delay) {
-    updated = true;
     departureTimes[stop] = getScheduledDepartureTime(stop) + delay;
     return this;
-  }
-
-  public RealTimeState realTimeState() {
-    if (realTimeState == null) {
-      return updated ? RealTimeState.UPDATED : RealTimeState.SCHEDULED;
-    }
-    return realTimeState;
-  }
-
-  public RealTimeTripTimesBuilder withRealTimeState(RealTimeState realTimeState) {
-    this.realTimeState = realTimeState;
-    return this;
-  }
-
-  public RealTimeTripTimesBuilder cancelTrip() {
-    return withRealTimeState(RealTimeState.CANCELED);
-  }
-
-  public RealTimeTripTimesBuilder deleteTrip() {
-    return withRealTimeState(RealTimeState.DELETED);
-  }
-
-  public StopRealTimeState getStopRealTimeState(int stop) {
-    return stopRealTimeStates[stop];
-  }
-
-  public StopRealTimeState[] stopRealTimeStates() {
-    return stopRealTimeStates.clone();
   }
 
   public BitSet extraCalls() {
@@ -217,23 +175,6 @@ public class RealTimeTripTimesBuilder {
 
   public BitSet hasDeparted() {
     return (BitSet) hasDeparted.clone();
-  }
-
-  public RealTimeTripTimesBuilder withCanceled(int stop) {
-    return withStopRealTimeState(stop, StopRealTimeState.CANCELLED);
-  }
-
-  public RealTimeTripTimesBuilder withNoData(int stop) {
-    return withStopRealTimeState(stop, StopRealTimeState.NO_DATA);
-  }
-
-  public RealTimeTripTimesBuilder withInaccuratePredictions(int stop) {
-    return withStopRealTimeState(stop, StopRealTimeState.INACCURATE_PREDICTIONS);
-  }
-
-  public RealTimeTripTimesBuilder withStopRealTimeState(int stop, StopRealTimeState state) {
-    this.stopRealTimeStates[stop] = state;
-    return this;
   }
 
   public RealTimeTripTimesBuilder withExtraCall(int stop, boolean extraCall) {
@@ -287,15 +228,6 @@ public class RealTimeTripTimesBuilder {
     return this;
   }
 
-  public OccupancyStatus[] occupancyStatus() {
-    return occupancyStatus.clone();
-  }
-
-  public RealTimeTripTimesBuilder withOccupancyStatus(int stop, OccupancyStatus occupancyStatus) {
-    this.occupancyStatus[stop] = occupancyStatus;
-    return this;
-  }
-
   public Accessibility wheelchairAccessibility() {
     if (wheelchairAccessibility == null) {
       return scheduledTripTimes.getWheelchairAccessibility();
@@ -336,6 +268,10 @@ public class RealTimeTripTimesBuilder {
       }
     }
     return hasCopiedTimes;
+  }
+
+  public TripRealTimeMetadata.TripRealTimeMetadataBuilder realTimeMetadataBuilder() {
+    return tripRealTimeMetadataBuilder;
   }
 
   public RealTimeTripTimes build() {

--- a/application/src/main/java/org/opentripplanner/transit/model/timetable/ScheduledTripTimes.java
+++ b/application/src/main/java/org/opentripplanner/transit/model/timetable/ScheduledTripTimes.java
@@ -73,6 +73,11 @@ public final class ScheduledTripTimes implements TripTimes<ScheduledTripTimes> {
 
   private final int[] gtfsSequenceOfStopIndex;
 
+  /**
+   * Cached default values (Scheduled trip, no updates) to avoid allocation on every call of Getter
+   */
+  private final TripRealTimeMetadata tripRealTimeMetadata;
+
   ScheduledTripTimes(ScheduledTripTimesBuilder builder) {
     this.timeShift = builder.timeShift();
     this.serviceCode = builder.serviceCode();
@@ -85,6 +90,9 @@ public final class ScheduledTripTimes implements TripTimes<ScheduledTripTimes> {
     this.headsigns = builder.headsigns();
     this.headsignVias = builder.headsignVias();
     this.gtfsSequenceOfStopIndex = builder.gtfsSequenceOfStopIndex();
+    this.tripRealTimeMetadata = TripRealTimeMetadata.defaultRealTimeMetadata(
+      builder.arrivalTimes().length
+    );
     validate();
   }
 
@@ -294,6 +302,11 @@ public final class ScheduledTripTimes implements TripTimes<ScheduledTripTimes> {
   @Override
   public OccupancyStatus getOccupancyStatus(int ignore) {
     return OccupancyStatus.NO_DATA_AVAILABLE;
+  }
+
+  @Override
+  public TripRealTimeMetadata getRealTimeMetadata() {
+    return this.tripRealTimeMetadata;
   }
 
   @Override

--- a/application/src/main/java/org/opentripplanner/transit/model/timetable/TripRealTimeMetadata.java
+++ b/application/src/main/java/org/opentripplanner/transit/model/timetable/TripRealTimeMetadata.java
@@ -1,0 +1,189 @@
+package org.opentripplanner.transit.model.timetable;
+
+import java.io.Serializable;
+import java.time.ZonedDateTime;
+import java.util.Arrays;
+import java.util.Objects;
+import javax.annotation.Nullable;
+
+/**
+ * Value Object containing Metadata about the realtime state of a Trip,
+ * such as the State of the Realtime Information at each stop, Vehicle occupancy etc.
+ * Used to encapsulate mostly API Relevant information.
+ */
+public class TripRealTimeMetadata implements Serializable {
+
+  private final RealTimeState realTimeState;
+  private final StopRealTimeState[] stopRealTimeStates;
+  private final OccupancyStatus[] occupancyStatuses;
+
+  @Nullable
+  private final ZonedDateTime lastUpdated;
+
+  private TripRealTimeMetadata(
+    RealTimeState realTimeState,
+    StopRealTimeState[] stopRealTimeStates,
+    OccupancyStatus[] occupancyStatuses,
+    ZonedDateTime lastUpdated
+  ) {
+    this.realTimeState = realTimeState;
+    this.stopRealTimeStates = stopRealTimeStates;
+    this.lastUpdated = lastUpdated;
+    this.occupancyStatuses = occupancyStatuses;
+  }
+
+  private TripRealTimeMetadata(int numStops) {
+    this(
+      RealTimeState.SCHEDULED,
+      defaultStopStates(numStops),
+      defaultOccupancyStatuses(numStops),
+      null
+    );
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    TripRealTimeMetadata that = (TripRealTimeMetadata) o;
+    return (
+      realTimeState == that.realTimeState &&
+      Objects.deepEquals(stopRealTimeStates, that.stopRealTimeStates) &&
+      Objects.equals(lastUpdated, that.lastUpdated) &&
+      Objects.deepEquals(occupancyStatuses, that.occupancyStatuses)
+    );
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(
+      realTimeState,
+      Arrays.hashCode(stopRealTimeStates),
+      lastUpdated,
+      Arrays.hashCode(occupancyStatuses)
+    );
+  }
+
+  public StopRealTimeState getRealTimeStateForStop(int index) {
+    return stopRealTimeStates[index];
+  }
+
+  public OccupancyStatus getOccupancyStatusForStop(int index) {
+    return occupancyStatuses[index];
+  }
+
+  public RealTimeState realTimeState() {
+    return realTimeState;
+  }
+
+  public ZonedDateTime lastUpdated() {
+    return lastUpdated;
+  }
+
+  /**
+   * The real-time states for a given stops. If the state is DEFAULT for a stop, the
+   * {@link #realTimeState()} should determine the realtime state of the stop.
+   * <p>
+   * This is only for API-purposes (does not affect routing).
+   */
+  public boolean hasStopRealTimeState(int stopPos, StopRealTimeState state) {
+    return stopRealTimeStates[stopPos] == state;
+  }
+
+  public static TripRealTimeMetadataBuilder builder(int numStops) {
+    return new TripRealTimeMetadataBuilder(numStops);
+  }
+
+  public static TripRealTimeMetadata defaultRealTimeMetadata(int numStops) {
+    return new TripRealTimeMetadata(numStops);
+  }
+
+  private static StopRealTimeState[] defaultStopStates(int numStops) {
+    StopRealTimeState[] states = new StopRealTimeState[numStops];
+    Arrays.fill(states, StopRealTimeState.DEFAULT);
+    return states;
+  }
+
+  private static OccupancyStatus[] defaultOccupancyStatuses(int numStops) {
+    OccupancyStatus[] statuses = new OccupancyStatus[numStops];
+    Arrays.fill(statuses, OccupancyStatus.NO_DATA_AVAILABLE);
+    return statuses;
+  }
+
+  public static class TripRealTimeMetadataBuilder {
+
+    private boolean receivedTimeUpdates = false;
+    private RealTimeState realTimeState;
+    private final StopRealTimeState[] stopRealTimeStates;
+    private ZonedDateTime lastUpdated;
+    private final OccupancyStatus[] occupancyStatuses;
+
+    private TripRealTimeMetadataBuilder(int numStops) {
+      stopRealTimeStates = new StopRealTimeState[numStops];
+      occupancyStatuses = new OccupancyStatus[numStops];
+      Arrays.fill(stopRealTimeStates, StopRealTimeState.DEFAULT);
+      Arrays.fill(occupancyStatuses, OccupancyStatus.NO_DATA_AVAILABLE);
+    }
+
+    public TripRealTimeMetadataBuilder withRealTimeState(RealTimeState realTimeState) {
+      this.realTimeState = realTimeState;
+      return this;
+    }
+
+    public TripRealTimeMetadataBuilder withRealTimeStateAtStop(
+      int index,
+      StopRealTimeState stopRealTimeState
+    ) {
+      stopRealTimeStates[index] = stopRealTimeState;
+      if (stopRealTimeState != StopRealTimeState.NO_DATA) {
+        receivedTimeUpdates = true;
+      }
+      return this;
+    }
+
+    public TripRealTimeMetadataBuilder withLastUpdated(ZonedDateTime lastUpdated) {
+      this.lastUpdated = lastUpdated;
+      return this;
+    }
+
+    public TripRealTimeMetadataBuilder withOccupancyAtStop(
+      int index,
+      OccupancyStatus occupancyStatus
+    ) {
+      occupancyStatuses[index] = occupancyStatus;
+      return this;
+    }
+
+    public TripRealTimeMetadataBuilder cancelTrip() {
+      return withRealTimeState(RealTimeState.CANCELED);
+    }
+
+    public TripRealTimeMetadataBuilder deleteTrip() {
+      return withRealTimeState(RealTimeState.DELETED);
+    }
+
+    public TripRealTimeMetadataBuilder withInaccuratePredictions(int stop) {
+      return withRealTimeStateAtStop(stop, StopRealTimeState.INACCURATE_PREDICTIONS);
+    }
+
+    public TripRealTimeMetadataBuilder withCanceled(int stop) {
+      return withRealTimeStateAtStop(stop, StopRealTimeState.CANCELLED);
+    }
+
+    public TripRealTimeMetadataBuilder withNoData(int stop) {
+      return withRealTimeStateAtStop(stop, StopRealTimeState.NO_DATA);
+    }
+
+    public StopRealTimeState getStopRealTimeState(int stop) {
+      return stopRealTimeStates[stop];
+    }
+
+    public TripRealTimeMetadata build() {
+      RealTimeState state = realTimeState == null
+        ? (receivedTimeUpdates ? RealTimeState.UPDATED : RealTimeState.SCHEDULED)
+        : realTimeState;
+      return new TripRealTimeMetadata(state, stopRealTimeStates, occupancyStatuses, lastUpdated);
+    }
+  }
+}

--- a/application/src/main/java/org/opentripplanner/transit/model/timetable/TripTimes.java
+++ b/application/src/main/java/org/opentripplanner/transit/model/timetable/TripTimes.java
@@ -186,6 +186,8 @@ public interface TripTimes<T extends TripTimes> extends Serializable, Comparable
    */
   OccupancyStatus getOccupancyStatus(int stopPos);
 
+  TripRealTimeMetadata getRealTimeMetadata();
+
   /**
    * Returns the GTFS sequence number of the given 0-based stop position within the pattern.
    * <p>

--- a/application/src/main/java/org/opentripplanner/updater/trip/TimetableSnapshotManager.java
+++ b/application/src/main/java/org/opentripplanner/updater/trip/TimetableSnapshotManager.java
@@ -183,7 +183,7 @@ public final class TimetableSnapshotManager {
       var scheduledTripTimes = scheduledPattern.getScheduledTimetable().getTripTimes(trip);
       if (scheduledTripTimes != null) {
         var builder = scheduledTripTimes.createRealTimeFromScheduledTimes();
-        builder.deleteTrip();
+        builder.realTimeMetadataBuilder().deleteTrip();
         buffer.update(
           RealTimeTripUpdate.of(scheduledPattern, builder.build(), serviceDate).build()
         );

--- a/application/src/main/java/org/opentripplanner/updater/trip/gtfs/BackwardsDelayRequiredInterpolator.java
+++ b/application/src/main/java/org/opentripplanner/updater/trip/gtfs/BackwardsDelayRequiredInterpolator.java
@@ -38,8 +38,11 @@ class BackwardsDelayRequiredInterpolator extends AbstractBackwardsDelayInterpola
       );
     }
     for (int i = firstUpdatedIndex - 1; i >= 0; i--) {
-      if (setNoData && builder.stopRealTimeStates()[i] != StopRealTimeState.CANCELLED) {
-        builder.withNoData(i);
+      if (
+        setNoData &&
+        builder.realTimeMetadataBuilder().getStopRealTimeState(i) != StopRealTimeState.CANCELLED
+      ) {
+        builder.realTimeMetadataBuilder().withNoData(i);
       }
       builder.withDepartureTime(i, time = Math.min(time, builder.getScheduledDepartureTime(i)));
       builder.withArrivalTime(i, time = Math.min(time, builder.getScheduledArrivalTime(i)));

--- a/application/src/main/java/org/opentripplanner/updater/trip/gtfs/DefaultForwardsDelayInterpolator.java
+++ b/application/src/main/java/org/opentripplanner/updater/trip/gtfs/DefaultForwardsDelayInterpolator.java
@@ -33,11 +33,15 @@ class DefaultForwardsDelayInterpolator implements ForwardsDelayInterpolator {
         firstRealUpdateSeen = true;
       }
       if (noTimeGiven) {
-        if (builder.getStopRealTimeState(i) == StopRealTimeState.DEFAULT) {
-          builder.withStopRealTimeState(i, propagatedState);
+        if (
+          builder.realTimeMetadataBuilder().getStopRealTimeState(i) == StopRealTimeState.DEFAULT
+        ) {
+          builder.realTimeMetadataBuilder().withRealTimeStateAtStop(i, propagatedState);
         }
 
-        if (builder.getStopRealTimeState(i) == StopRealTimeState.CANCELLED) {
+        if (
+          builder.realTimeMetadataBuilder().getStopRealTimeState(i) == StopRealTimeState.CANCELLED
+        ) {
           if (firstCanceledStop == null) {
             firstCanceledStop = i;
           }
@@ -49,7 +53,10 @@ class DefaultForwardsDelayInterpolator implements ForwardsDelayInterpolator {
         // only fill in times for NO_DATA stops after the first updated stop
         // otherwise, it is the job of the backward interpolator to fill in the times backward
         // see bug https://github.com/opentripplanner/OpenTripPlanner/issues/7097 for details
-        if (builder.getStopRealTimeState(i) == StopRealTimeState.NO_DATA && firstRealUpdateSeen) {
+        if (
+          builder.realTimeMetadataBuilder().getStopRealTimeState(i) == StopRealTimeState.NO_DATA &&
+          firstRealUpdateSeen
+        ) {
           // for NO_DATA stops, try to use the scheduled time. However, if the schedule time is
           // earlier than the delayed departure of the previous stop, we cannot set an earlier time
           // than that.
@@ -73,7 +80,10 @@ class DefaultForwardsDelayInterpolator implements ForwardsDelayInterpolator {
       delay = builder.getArrivalDelay(i);
 
       if (builder.getDepartureDelay(i) == null) {
-        if (builder.getStopRealTimeState(i) == StopRealTimeState.NO_DATA && firstRealUpdateSeen) {
+        if (
+          builder.realTimeMetadataBuilder().getStopRealTimeState(i) == StopRealTimeState.NO_DATA &&
+          firstRealUpdateSeen
+        ) {
           // for NO_DATA stops, try to use the scheduled time. However, if the schedule time is
           // earlier than the delayed arrival of this stop, we cannot set an earlier time
           // than that.
@@ -125,7 +135,7 @@ class DefaultForwardsDelayInterpolator implements ForwardsDelayInterpolator {
       }
       firstCanceledStop = null;
 
-      var state = builder.getStopRealTimeState(i);
+      var state = builder.realTimeMetadataBuilder().getStopRealTimeState(i);
       // NO_DATA should be propagated per the spec, SKIPPED should not
       // GTFS does not support INACCURATE_PREDICTIONS, but I think it should be propagated as well
       if (state == StopRealTimeState.NO_DATA || state == StopRealTimeState.INACCURATE_PREDICTIONS) {

--- a/application/src/main/java/org/opentripplanner/updater/trip/gtfs/GtfsRealTimeTripUpdateAdapter.java
+++ b/application/src/main/java/org/opentripplanner/updater/trip/gtfs/GtfsRealTimeTripUpdateAdapter.java
@@ -439,8 +439,8 @@ public class GtfsRealTimeTripUpdateAdapter {
           if (tripTimes != null && tripTimes.getRealTimeState() == RealTimeState.ADDED) {
             var builder = tripTimes.createRealTimeFromScheduledTimes();
             switch (cancelationType) {
-              case CANCEL -> builder.cancelTrip();
-              case DELETE -> builder.deleteTrip();
+              case CANCEL -> builder.realTimeMetadataBuilder().cancelTrip();
+              case DELETE -> builder.realTimeMetadataBuilder().deleteTrip();
             }
             return snapshotManager.updateBuffer(
               RealTimeTripUpdate.of(addedPattern, builder.build(), tripUpdate.serviceDate()).build()
@@ -463,8 +463,8 @@ public class GtfsRealTimeTripUpdateAdapter {
 
     var builder = tripTimes.createRealTimeFromScheduledTimes();
     switch (cancelationType) {
-      case CANCEL -> builder.cancelTrip();
-      case DELETE -> builder.deleteTrip();
+      case CANCEL -> builder.realTimeMetadataBuilder().cancelTrip();
+      case DELETE -> builder.realTimeMetadataBuilder().deleteTrip();
     }
     return snapshotManager.updateBuffer(
       RealTimeTripUpdate.of(pattern, builder.build(), tripUpdate.serviceDate())

--- a/application/src/main/java/org/opentripplanner/updater/trip/gtfs/TripTimesUpdater.java
+++ b/application/src/main/java/org/opentripplanner/updater/trip/gtfs/TripTimesUpdater.java
@@ -121,11 +121,11 @@ class TripTimesUpdater {
         // Set status to cancelled
         updatedPickups.put(pos, PickDrop.CANCELLED);
         updatedDropoffs.put(pos, PickDrop.CANCELLED);
-        builder.withCanceled(pos);
+        builder.realTimeMetadataBuilder().withCanceled(pos);
       } else if (scheduleRelationship == ScheduleRelationship.NO_DATA) {
         // Set status to NO_DATA and delays to 0.
         // Note: GTFS-RT requires NO_DATA stops to have no arrival departure times.
-        builder.withNoData(pos);
+        builder.realTimeMetadataBuilder().withNoData(pos);
       } else {
         // Else the status is SCHEDULED, update times as needed.
         if (!update.isArrivalValid()) {
@@ -147,7 +147,7 @@ class TripTimesUpdater {
     tripUpdate.wheelchairAccessibility().ifPresent(builder::withWheelchairAccessibility);
 
     // Make sure that updated trip times have the correct real time state
-    builder.withRealTimeState(RealTimeState.UPDATED);
+    builder.realTimeMetadataBuilder().withRealTimeState(RealTimeState.UPDATED);
 
     // Validate for non-increasing times. Log error if present.
     try {
@@ -228,7 +228,7 @@ class TripTimesUpdater {
       final var addedStopTime = stopAndStopTimeUpdates.get(stopIndex).stopTimeUpdate();
 
       if (addedStopTime.isSkipped()) {
-        builder.withCanceled(stopIndex);
+        builder.realTimeMetadataBuilder().withCanceled(stopIndex);
       }
 
       setArrivalAndDeparture(builder, stopIndex, addedStopTime, midnightSecondsSinceEpoch);
@@ -240,8 +240,9 @@ class TripTimesUpdater {
       }
     }
 
+    builder.realTimeMetadataBuilder().withRealTimeState(realTimeState);
     // Set service code of new trip times
-    builder.withServiceCode(serviceCode).withRealTimeState(realTimeState);
+    builder.withServiceCode(serviceCode);
 
     tripUpdate.tripHeadsign().ifPresent(builder::withTripHeadsign);
     tripUpdate.wheelchairAccessibility().ifPresent(builder::withWheelchairAccessibility);

--- a/application/src/main/java/org/opentripplanner/updater/trip/siri/AddedTripBuilder.java
+++ b/application/src/main/java/org/opentripplanner/updater/trip/siri/AddedTripBuilder.java
@@ -249,21 +249,35 @@ class AddedTripBuilder {
 
     // Loop through calls again and apply updates
     for (int stopSequence = 0; stopSequence < calls.size(); stopSequence++) {
+      CallWrapper call = calls.get(stopSequence);
       TimetableHelper.applyUpdates(
         departureDate,
         builder,
         stopSequence,
         stopSequence == (calls.size() - 1),
-        isJourneyPredictionInaccurate,
-        calls.get(stopSequence),
-        occupancy
+        call
+      );
+      SiriRealTimeMetadataHelper.updateRealTimeMetadataAtStop(
+        builder.realTimeMetadataBuilder(),
+        stopSequence,
+        call,
+        occupancy,
+        isJourneyPredictionInaccurate
       );
     }
 
     if (cancellation || stopPattern.isAllStopsNonRoutable()) {
-      builder.cancelTrip();
+      SiriRealTimeMetadataHelper.updateRealTimeMetadataForJourney(
+        builder.realTimeMetadataBuilder(),
+        null,
+        RealTimeState.CANCELED
+      );
     } else {
-      builder.withRealTimeState(RealTimeState.ADDED);
+      SiriRealTimeMetadataHelper.updateRealTimeMetadataForJourney(
+        builder.realTimeMetadataBuilder(),
+        null,
+        RealTimeState.ADDED
+      );
     }
 
     /* Validate */

--- a/application/src/main/java/org/opentripplanner/updater/trip/siri/ExtraCallTripBuilder.java
+++ b/application/src/main/java/org/opentripplanner/updater/trip/siri/ExtraCallTripBuilder.java
@@ -160,21 +160,35 @@ class ExtraCallTripBuilder {
 
     // Loop through calls again and apply updates
     for (int stopSequence = 0; stopSequence < calls.size(); stopSequence++) {
+      CallWrapper call = calls.get(stopSequence);
       TimetableHelper.applyUpdates(
         departureDate,
         builder,
         stopSequence,
         stopSequence == (calls.size() - 1),
-        isJourneyPredictionInaccurate,
-        calls.get(stopSequence),
-        occupancy
+        call
+      );
+      SiriRealTimeMetadataHelper.updateRealTimeMetadataAtStop(
+        builder.realTimeMetadataBuilder(),
+        stopSequence,
+        call,
+        occupancy,
+        isJourneyPredictionInaccurate
       );
     }
 
     if (cancellation || stopPattern.isAllStopsNonRoutable()) {
-      builder.cancelTrip();
+      SiriRealTimeMetadataHelper.updateRealTimeMetadataForJourney(
+        builder.realTimeMetadataBuilder(),
+        null,
+        RealTimeState.CANCELED
+      );
     } else {
-      builder.withRealTimeState(RealTimeState.MODIFIED);
+      SiriRealTimeMetadataHelper.updateRealTimeMetadataForJourney(
+        builder.realTimeMetadataBuilder(),
+        null,
+        RealTimeState.MODIFIED
+      );
     }
 
     /* Validate */

--- a/application/src/main/java/org/opentripplanner/updater/trip/siri/ModifiedTripBuilder.java
+++ b/application/src/main/java/org/opentripplanner/updater/trip/siri/ModifiedTripBuilder.java
@@ -133,15 +133,7 @@ class ModifiedTripBuilder {
       return cancelTrip(builder);
     }
 
-    applyUpdates(builder);
-
-    if (pattern.getStopPattern().equals(stopPattern)) {
-      // This is the first update, and StopPattern has not been changed
-      builder.withRealTimeState(RealTimeState.UPDATED);
-    } else {
-      // This update modified stopPattern
-      builder.withRealTimeState(RealTimeState.MODIFIED);
-    }
+    applyUpdates(builder, stopPattern);
 
     int numStopsInUpdate = builder.numberOfStops();
     int numStopsInPattern = pattern.numberOfStops();
@@ -174,7 +166,7 @@ class ModifiedTripBuilder {
    * Full cancellation of a trip.
    */
   private TripUpdate cancelTrip(RealTimeTripTimesBuilder builder) {
-    builder.cancelTrip();
+    builder.realTimeMetadataBuilder().cancelTrip();
     return new TripUpdate(pattern.getStopPattern(), builder.build(), serviceDate, dataSource);
   }
 
@@ -183,7 +175,7 @@ class ModifiedTripBuilder {
    * Precondition: the number of calls is equal to the number of stops in the pattern (this is
    * verified before calling this method).
    */
-  private void applyUpdates(RealTimeTripTimesBuilder builder) {
+  private void applyUpdates(RealTimeTripTimesBuilder builder, StopPattern stopPattern) {
     ZonedDateTime startOfService = ServiceDateUtils.asStartOfService(serviceDate, zoneId);
     Set<CallWrapper> alreadyVisited = new HashSet<>();
 
@@ -218,12 +210,34 @@ class ModifiedTripBuilder {
         builder,
         stopIndex,
         stopIndex == (stopsInPattern.size() - 1),
-        predictionInaccurate,
+        matchingCall
+      );
+
+      SiriRealTimeMetadataHelper.updateRealTimeMetadataAtStop(
+        builder.realTimeMetadataBuilder(),
+        stopIndex,
         matchingCall,
-        occupancy
+        occupancy,
+        predictionInaccurate
       );
 
       alreadyVisited.add(matchingCall);
+    }
+
+    if (pattern.getStopPattern().equals(stopPattern)) {
+      // This is the first update, and StopPattern has not been changed
+      SiriRealTimeMetadataHelper.updateRealTimeMetadataForJourney(
+        builder.realTimeMetadataBuilder(),
+        null,
+        RealTimeState.UPDATED
+      );
+    } else {
+      // This update modified stopPattern
+      SiriRealTimeMetadataHelper.updateRealTimeMetadataForJourney(
+        builder.realTimeMetadataBuilder(),
+        null,
+        RealTimeState.MODIFIED
+      );
     }
   }
 

--- a/application/src/main/java/org/opentripplanner/updater/trip/siri/SiriRealTimeMetadataHelper.java
+++ b/application/src/main/java/org/opentripplanner/updater/trip/siri/SiriRealTimeMetadataHelper.java
@@ -1,0 +1,74 @@
+package org.opentripplanner.updater.trip.siri;
+
+import java.time.ZonedDateTime;
+import org.opentripplanner.transit.model.timetable.OccupancyStatus;
+import org.opentripplanner.transit.model.timetable.RealTimeState;
+import org.opentripplanner.transit.model.timetable.StopRealTimeState;
+import org.opentripplanner.transit.model.timetable.TripRealTimeMetadata;
+import org.opentripplanner.updater.trip.siri.mapping.OccupancyMapper;
+import uk.org.siri.siri21.OccupancyEnumeration;
+
+/**
+ * Helper class, that provides methods, to update a TripRealTimeMetadataBuilder
+ * with relevant Metadata at journey or Stop level for Siri-ET Realtime updates.
+ * Usually gets called in conjunction with {@link TimetableHelper} to update triptimes.
+ */
+public class SiriRealTimeMetadataHelper {
+
+  public static void updateRealTimeMetadataAtStop(
+    TripRealTimeMetadata.TripRealTimeMetadataBuilder builder,
+    int stopIndex,
+    CallWrapper call,
+    OccupancyEnumeration journeyOccupancy,
+    boolean isJourneyPredictionInaccurate
+  ) {
+    builder
+      .withRealTimeStateAtStop(
+        stopIndex,
+        determineRealTimeState(call, isJourneyPredictionInaccurate)
+      )
+      .withOccupancyAtStop(stopIndex, determineOccupancyStatus(call, journeyOccupancy));
+  }
+
+  public static void updateRealTimeMetadataForJourney(
+    TripRealTimeMetadata.TripRealTimeMetadataBuilder builder,
+    ZonedDateTime lastUpdated,
+    RealTimeState realTimeState
+  ) {
+    builder.withLastUpdated(lastUpdated).withRealTimeState(realTimeState);
+  }
+
+  private static OccupancyStatus determineOccupancyStatus(
+    CallWrapper call,
+    OccupancyEnumeration journeyOccupancy
+  ) {
+    OccupancyEnumeration callOccupancy = call.getOccupancy() != null
+      ? call.getOccupancy()
+      : journeyOccupancy;
+    return OccupancyMapper.mapOccupancyStatus(callOccupancy);
+  }
+
+  private static StopRealTimeState determineRealTimeState(
+    CallWrapper call,
+    boolean isJourneyPredictionInaccurate
+  ) {
+    if (Boolean.TRUE.equals(call.isCancellation())) {
+      return StopRealTimeState.CANCELLED;
+    }
+    if (isJourneyPredictionInaccurate || Boolean.TRUE.equals(call.isPredictionInaccurate())) {
+      return StopRealTimeState.INACCURATE_PREDICTIONS;
+    }
+    if (
+      call.getActualArrivalTime() == null &&
+      call.getActualDepartureTime() == null &&
+      call.getExpectedArrivalTime() == null &&
+      call.getExpectedDepartureTime() == null
+    ) {
+      return StopRealTimeState.NO_DATA;
+    }
+    if (call.isRecorded()) {
+      return StopRealTimeState.RECORDED;
+    }
+    return StopRealTimeState.DEFAULT;
+  }
+}

--- a/application/src/main/java/org/opentripplanner/updater/trip/siri/TimetableHelper.java
+++ b/application/src/main/java/org/opentripplanner/updater/trip/siri/TimetableHelper.java
@@ -1,15 +1,11 @@
 package org.opentripplanner.updater.trip.siri;
 
-import static java.lang.Boolean.TRUE;
-
 import java.time.ZonedDateTime;
 import java.util.function.Supplier;
 import org.opentripplanner.core.model.i18n.NonLocalizedString;
 import org.opentripplanner.transit.model.timetable.RealTimeTripTimesBuilder;
-import org.opentripplanner.updater.trip.siri.mapping.OccupancyMapper;
 import org.opentripplanner.utils.time.ServiceDateUtils;
 import uk.org.siri.siri21.NaturalLanguageStringStructure;
-import uk.org.siri.siri21.OccupancyEnumeration;
 
 class TimetableHelper {
 
@@ -55,22 +51,10 @@ class TimetableHelper {
     RealTimeTripTimesBuilder tripTimesBuilder,
     int index,
     boolean isLastStop,
-    boolean isJourneyPredictionInaccurate,
-    CallWrapper call,
-    OccupancyEnumeration journeyOccupancy
+    CallWrapper call
   ) {
     tripTimesBuilder.withHasArrived(index, call.hasArrived());
     tripTimesBuilder.withHasDeparted(index, call.hasDeparted());
-
-    // Set flag for inaccurate prediction if either call OR journey has inaccurate-flag set.
-    boolean isCallPredictionInaccurate = TRUE.equals(call.isPredictionInaccurate());
-    if (isJourneyPredictionInaccurate || isCallPredictionInaccurate) {
-      tripTimesBuilder.withInaccuratePredictions(index);
-    }
-
-    if (TRUE.equals(call.isCancellation())) {
-      tripTimesBuilder.withCanceled(index);
-    }
 
     if (call.isExtraCall()) {
       tripTimesBuilder.withExtraCall(index, true);
@@ -104,17 +88,6 @@ class TimetableHelper {
     var departureTime = handleMissingRealtime(possibleDepartureTimes);
     int departureDelay = departureTime - scheduledDepartureTime;
     tripTimesBuilder.withDepartureDelay(index, departureDelay);
-
-    OccupancyEnumeration callOccupancy = call.getOccupancy() != null
-      ? call.getOccupancy()
-      : journeyOccupancy;
-
-    if (callOccupancy != null) {
-      tripTimesBuilder.withOccupancyStatus(
-        index,
-        OccupancyMapper.mapOccupancyStatus(callOccupancy)
-      );
-    }
 
     if (call.getDestinationDisplays() != null && !call.getDestinationDisplays().isEmpty()) {
       NaturalLanguageStringStructure destinationDisplay = call.getDestinationDisplays().get(0);

--- a/application/src/test/java/org/opentripplanner/apis/gtfs/GraphQLIntegrationTest.java
+++ b/application/src/test/java/org/opentripplanner/apis/gtfs/GraphQLIntegrationTest.java
@@ -117,6 +117,7 @@ import org.opentripplanner.transit.model.site.Entrance;
 import org.opentripplanner.transit.model.site.RegularStop;
 import org.opentripplanner.transit.model.site.Station;
 import org.opentripplanner.transit.model.site.StopLocation;
+import org.opentripplanner.transit.model.timetable.RealTimeState;
 import org.opentripplanner.transit.model.timetable.RealTimeTripUpdate;
 import org.opentripplanner.transit.model.timetable.TimetableSnapshot;
 import org.opentripplanner.transit.model.timetable.Trip;
@@ -272,12 +273,10 @@ class GraphQLIntegrationTest {
     timetableRepository.index();
 
     TimetableSnapshot timetableSnapshot = new TimetableSnapshot();
+    var realTimeFromScheduledTimes = tripTimes2.createRealTimeFromScheduledTimes();
+    realTimeFromScheduledTimes.realTimeMetadataBuilder().cancelTrip();
     timetableSnapshot.update(
-      RealTimeTripUpdate.of(
-        pattern,
-        tripTimes2.createRealTimeFromScheduledTimes().cancelTrip().build(),
-        secondDate
-      ).build()
+      RealTimeTripUpdate.of(pattern, realTimeFromScheduledTimes.build(), secondDate).build()
     );
 
     var routes = Stream.concat(
@@ -558,6 +557,7 @@ class GraphQLIntegrationTest {
             builder.withDepartureTime(i, scheduledTimes.getDepartureTime(i) + TEN_MINUTES);
           }
 
+          builder.realTimeMetadataBuilder().withRealTimeState(RealTimeState.UPDATED);
           return stl.copyOf().withTripTimes(builder.build()).build();
         }
         return tl;

--- a/application/src/test/java/org/opentripplanner/model/plan/leg/ScheduledTransitLegTest.java
+++ b/application/src/test/java/org/opentripplanner/model/plan/leg/ScheduledTransitLegTest.java
@@ -27,6 +27,7 @@ import org.opentripplanner.transit.model._data.TripOnDateDataFetcher;
 import org.opentripplanner.transit.model.basic.Money;
 import org.opentripplanner.transit.model.network.TripPattern;
 import org.opentripplanner.transit.model.site.RegularStop;
+import org.opentripplanner.transit.model.timetable.RealTimeState;
 import org.opentripplanner.transit.model.timetable.RealTimeTripTimes;
 import org.opentripplanner.transit.model.timetable.TripTimes;
 
@@ -64,16 +65,9 @@ class ScheduledTransitLegTest {
   private static final int GENERALIZED_COST = 980;
   private static final ZoneId ZONE_ID = ZoneIds.BERLIN;
   private static final Duration DELAY = Duration.ofMinutes(4);
-  private static final RealTimeTripTimes REAL_TIME_TRIP_TIMES =
-    TRIP_TIMES.createRealTimeFromScheduledTimes()
-      .withDepartureTime(
-        BOARD_STOP_INDEX_IN_PATTERN,
-        TRIP_TIMES.getScheduledDepartureTime(BOARD_STOP_INDEX_IN_PATTERN) + (int) DELAY.toSeconds()
-      )
-      .build();
+  private static final RealTimeTripTimes REAL_TIME_TRIP_TIMES = makeRealTimeTripTimes();
   private static final ViaLocationType FROM_VIA_LOCATION_TYPE = ViaLocationType.PASS_THROUGH;
   private static final ViaLocationType TO_VIA_LOCATION_TYPE = ViaLocationType.VISIT;
-
   private static final Set<TransitAlert> ALERTS = Set.of(
     TransitAlert.of(id("alert")).withDescriptionText(I18NString.of("alert")).build()
   );
@@ -82,7 +76,6 @@ class ScheduledTransitLegTest {
   private static final List<FareProduct> FARE_PRODUCTS = List.of(
     FareProduct.of(id("fp"), "fare product", Money.euros(10.00f)).build()
   );
-
   private final ScheduledTransitLeg subject = new ScheduledTransitLegBuilder()
     .withTripTimes(REAL_TIME_TRIP_TIMES)
     .withTripPattern(PATTERN)
@@ -99,6 +92,15 @@ class ScheduledTransitLegTest {
     .withFromViaLocationType(FROM_VIA_LOCATION_TYPE)
     .withToViaLocationType(TO_VIA_LOCATION_TYPE)
     .build();
+
+  private static RealTimeTripTimes makeRealTimeTripTimes() {
+    var realTimeTripTimes = TRIP_TIMES.createRealTimeFromScheduledTimes().withDepartureTime(
+      BOARD_STOP_INDEX_IN_PATTERN,
+      TRIP_TIMES.getScheduledDepartureTime(BOARD_STOP_INDEX_IN_PATTERN) + (int) DELAY.toSeconds()
+    );
+    realTimeTripTimes.realTimeMetadataBuilder().withRealTimeState(RealTimeState.UPDATED);
+    return realTimeTripTimes.build();
+  }
 
   @Test
   void testMinimalSetOfFieldsSet() {

--- a/application/src/test/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/request/DefaultTransitDataProviderFilterTest.java
+++ b/application/src/test/java/org/opentripplanner/routing/algorithm/raptoradapter/transit/request/DefaultTransitDataProviderFilterTest.java
@@ -679,11 +679,9 @@ class DefaultTransitDataProviderFilterTest {
       TripAlteration.PLANNED
     );
 
-    var cancelled = patternTimes
-      .tripTimes()
-      .createRealTimeFromScheduledTimes()
-      .cancelTrip()
-      .build();
+    var builder = patternTimes.tripTimes().createRealTimeFromScheduledTimes();
+    builder.realTimeMetadataBuilder().cancelTrip();
+    var cancelled = builder.build();
 
     var patternTimesWithCancellation = patternTimes.withTimes(cancelled);
 

--- a/application/src/test/java/org/opentripplanner/transit/model/timetable/RealTimeTripTimesTest.java
+++ b/application/src/test/java/org/opentripplanner/transit/model/timetable/RealTimeTripTimesTest.java
@@ -208,7 +208,7 @@ class RealTimeTripTimesTest {
     builder.withDepartureTime(5, 421);
     builder.withArrivalTime(6, 481);
     builder.withDepartureTime(6, 481);
-    builder.withCanceled(6);
+    builder.realTimeMetadataBuilder().withCanceled(6);
     builder.withArrivalTime(7, 420);
 
     var error = assertThrows(DataValidationException.class, builder::build);
@@ -229,7 +229,7 @@ class RealTimeTripTimesTest {
     var builder = createInitialTripTimes().createRealTimeFromScheduledTimes();
 
     builder.withDepartureTime(5, 300);
-    builder.withCanceled(6);
+    builder.realTimeMetadataBuilder().withCanceled(6);
     builder.withArrivalTime(7, 320);
 
     var error = assertThrows(DataValidationException.class, builder::build);
@@ -249,8 +249,8 @@ class RealTimeTripTimesTest {
   public void testPositiveHopTimeWithTerminalCancellation() {
     var builder = createInitialTripTimes().createRealTimeFromScheduledTimes();
 
-    builder.withCanceled(0);
-    builder.withCanceled(1);
+    builder.realTimeMetadataBuilder().withCanceled(0);
+    builder.realTimeMetadataBuilder().withCanceled(1);
     builder.withArrivalTime(2, 0);
     builder.withDepartureTime(2, 10);
 
@@ -271,12 +271,12 @@ class RealTimeTripTimesTest {
   public void testMultipleStopCancellations() {
     var builder = createInitialTripTimes().createRealTimeFromScheduledTimes();
 
-    builder.withCanceled(1);
-    builder.withCanceled(2);
-    builder.withCanceled(3);
-    builder.withCanceled(4);
-    builder.withCanceled(5);
-    builder.withCanceled(6);
+    builder.realTimeMetadataBuilder().withCanceled(1);
+    builder.realTimeMetadataBuilder().withCanceled(2);
+    builder.realTimeMetadataBuilder().withCanceled(3);
+    builder.realTimeMetadataBuilder().withCanceled(4);
+    builder.realTimeMetadataBuilder().withCanceled(5);
+    builder.realTimeMetadataBuilder().withCanceled(6);
     builder.withArrivalTime(7, 350);
     builder.withDepartureTime(7, 350);
 
@@ -297,13 +297,13 @@ class RealTimeTripTimesTest {
   public void testMultipleStopCancellations2() {
     var builder = createInitialTripTimes().createRealTimeFromScheduledTimes();
 
-    builder.withCanceled(1);
-    builder.withCanceled(2);
+    builder.realTimeMetadataBuilder().withCanceled(1);
+    builder.realTimeMetadataBuilder().withCanceled(2);
     builder.withArrivalTime(3, 90);
     builder.withDepartureTime(3, 90);
-    builder.withCanceled(4);
-    builder.withCanceled(5);
-    builder.withCanceled(6);
+    builder.realTimeMetadataBuilder().withCanceled(4);
+    builder.realTimeMetadataBuilder().withCanceled(5);
+    builder.realTimeMetadataBuilder().withCanceled(6);
     builder.withArrivalTime(7, 240);
     builder.withDepartureTime(7, 240);
 
@@ -338,14 +338,14 @@ class RealTimeTripTimesTest {
   @Test
   public void testCancel() {
     var builder = createInitialTripTimes().createRealTimeFromScheduledTimes();
-    builder.cancelTrip();
+    builder.realTimeMetadataBuilder().cancelTrip();
     assertEquals(RealTimeState.CANCELED, builder.build().getRealTimeState());
   }
 
   @Test
   public void testNoData() {
     var builder = createInitialTripTimes().createRealTimeFromScheduledTimes();
-    builder.withNoData(1);
+    builder.realTimeMetadataBuilder().withNoData(1);
     var updatedTripTimesA = builder.build();
     assertFalse(updatedTripTimesA.isNoDataStop(0));
     assertTrue(updatedTripTimesA.isNoDataStop(1));
@@ -356,9 +356,9 @@ class RealTimeTripTimesTest {
   public void testRealTimeUpdated() {
     var builder = createInitialTripTimes().createRealTimeFromScheduledTimes();
     assertFalse(builder.build().isRealTimeUpdated(1));
-    builder.withRealTimeState(RealTimeState.UPDATED);
+    builder.realTimeMetadataBuilder().withRealTimeState(RealTimeState.UPDATED);
     assertTrue(builder.build().isRealTimeUpdated(1));
-    builder.withNoData(1);
+    builder.realTimeMetadataBuilder().withNoData(1);
     var updatedTripTimesA = builder.build();
     assertTrue(updatedTripTimesA.isRealTimeUpdated(0));
     assertFalse(updatedTripTimesA.isRealTimeUpdated(1));

--- a/application/src/test/java/org/opentripplanner/transit/service/DefaultTransitServiceTest.java
+++ b/application/src/test/java/org/opentripplanner/transit/service/DefaultTransitServiceTest.java
@@ -155,10 +155,13 @@ class DefaultTransitServiceTest {
     var deduplicator = new Deduplicator();
     var timetableRepository = new TimetableRepository(siteRepository);
     var canceledStopTimes = TEST_MODEL.stopTimesEvery5Minutes(3, TRIP, "11:30");
-    var canceledTripTimes = TripTimesFactory.tripTimes(TRIP, canceledStopTimes, deduplicator)
-      .createRealTimeFromScheduledTimes()
-      .cancelTrip()
-      .build();
+    var canceledTripTimesBuilder = TripTimesFactory.tripTimes(
+      TRIP,
+      canceledStopTimes,
+      deduplicator
+    ).createRealTimeFromScheduledTimes();
+    canceledTripTimesBuilder.realTimeMetadataBuilder().cancelTrip();
+    var canceledTripTimes = canceledTripTimesBuilder.build();
     timetableRepository.addTripPattern(RAIL_PATTERN.getId(), RAIL_PATTERN);
 
     // Crate a calendar (needed for testing cancelled trips)

--- a/application/src/test/java/org/opentripplanner/transit/service/StopTimesHelperTest.java
+++ b/application/src/test/java/org/opentripplanner/transit/service/StopTimesHelperTest.java
@@ -41,7 +41,7 @@ class StopTimesHelperTest {
     );
     var tt = originalPattern.getScheduledTimetable();
     var newTripTimes = tt.getTripTimes().getFirst().createRealTimeFromScheduledTimes();
-    newTripTimes.cancelTrip();
+    newTripTimes.realTimeMetadataBuilder().cancelTrip();
     pattern = originalPattern
       .copy()
       .withScheduledTimeTableBuilder(builder -> builder.addOrUpdateTripTimes(newTripTimes.build()))

--- a/application/src/test/java/org/opentripplanner/updater/trip/TimetableSnapshotManagerTest.java
+++ b/application/src/test/java/org/opentripplanner/updater/trip/TimetableSnapshotManagerTest.java
@@ -183,10 +183,12 @@ class TimetableSnapshotManagerTest {
       .withArrivalDelay(0, 60)
       .withDepartureDelay(0, 60)
       .withArrivalDelay(1, 60)
-      .withDepartureDelay(1, 60)
-      .build();
+      .withDepartureDelay(1, 60);
+    rtTripTimes.realTimeMetadataBuilder().withRealTimeState(RealTimeState.UPDATED);
 
-    manager.updateBuffer(RealTimeTripUpdate.of(SCHEDULED_PATTERN, rtTripTimes, TODAY).build());
+    manager.updateBuffer(
+      RealTimeTripUpdate.of(SCHEDULED_PATTERN, rtTripTimes.build(), TODAY).build()
+    );
 
     var timetable = manager.resolve(SCHEDULED_PATTERN, TODAY);
     var tripTimes = timetable.getTripTimes(TRIP);
@@ -205,11 +207,11 @@ class TimetableSnapshotManagerTest {
       .withArrivalDelay(0, 60)
       .withDepartureDelay(0, 60)
       .withArrivalDelay(1, 60)
-      .withDepartureDelay(1, 60)
-      .build();
+      .withDepartureDelay(1, 60);
+    rtTripTimes.realTimeMetadataBuilder().withRealTimeState(RealTimeState.UPDATED);
 
     manager.updateBuffer(
-      RealTimeTripUpdate.of(MODIFIED_PATTERN, rtTripTimes, TODAY)
+      RealTimeTripUpdate.of(MODIFIED_PATTERN, rtTripTimes.build(), TODAY)
         .withHideTripInScheduledPattern(SCHEDULED_PATTERN)
         .build()
     );
@@ -237,12 +239,13 @@ class TimetableSnapshotManagerTest {
       .withArrivalDelay(0, 60)
       .withDepartureDelay(0, 60)
       .withArrivalDelay(1, 60)
-      .withDepartureDelay(1, 60)
-      .build();
+      .withDepartureDelay(1, 60);
+    rtTripTimes.realTimeMetadataBuilder().withRealTimeState(RealTimeState.UPDATED);
 
     // Setup: move the trip to the modified pattern
+    var realTimeTripTimes = rtTripTimes.build();
     manager.updateBuffer(
-      RealTimeTripUpdate.of(MODIFIED_PATTERN, rtTripTimes, TODAY)
+      RealTimeTripUpdate.of(MODIFIED_PATTERN, realTimeTripTimes, TODAY)
         .withHideTripInScheduledPattern(SCHEDULED_PATTERN)
         .build()
     );
@@ -252,7 +255,7 @@ class TimetableSnapshotManagerTest {
 
     // Now revert and update on the scheduled pattern
     manager.updateBuffer(
-      RealTimeTripUpdate.of(SCHEDULED_PATTERN, rtTripTimes, TODAY)
+      RealTimeTripUpdate.of(SCHEDULED_PATTERN, realTimeTripTimes, TODAY)
         .withRevertPreviousRealTimeUpdates(true)
         .build()
     );
@@ -276,12 +279,13 @@ class TimetableSnapshotManagerTest {
       .withArrivalDelay(0, 60)
       .withDepartureDelay(0, 60)
       .withArrivalDelay(1, 60)
-      .withDepartureDelay(1, 60)
-      .build();
+      .withDepartureDelay(1, 60);
+    rtTripTimes.realTimeMetadataBuilder().withRealTimeState(RealTimeState.UPDATED);
+    var realTimeTripTimes = rtTripTimes.build();
 
     // Setup: move the trip to the first modified pattern
     manager.updateBuffer(
-      RealTimeTripUpdate.of(MODIFIED_PATTERN, rtTripTimes, TODAY)
+      RealTimeTripUpdate.of(MODIFIED_PATTERN, realTimeTripTimes, TODAY)
         .withHideTripInScheduledPattern(SCHEDULED_PATTERN)
         .build()
     );
@@ -292,7 +296,7 @@ class TimetableSnapshotManagerTest {
     // Now revert from the first modified pattern, delete from scheduled, and update on the
     // second modified pattern
     manager.updateBuffer(
-      RealTimeTripUpdate.of(SECOND_MODIFIED_PATTERN, rtTripTimes, TODAY)
+      RealTimeTripUpdate.of(SECOND_MODIFIED_PATTERN, realTimeTripTimes, TODAY)
         .withRevertPreviousRealTimeUpdates(true)
         .withHideTripInScheduledPattern(SCHEDULED_PATTERN)
         .build()
@@ -323,12 +327,11 @@ class TimetableSnapshotManagerTest {
   @Test
   void updateBufferCancelScheduledTrip() {
     var manager = createManager();
-    var canceledTripTimes = SCHEDULED_TRIP_TIMES.createRealTimeFromScheduledTimes()
-      .cancelTrip()
-      .build();
+    var canceledTripTimes = SCHEDULED_TRIP_TIMES.createRealTimeFromScheduledTimes();
+    canceledTripTimes.realTimeMetadataBuilder().cancelTrip();
 
     manager.updateBuffer(
-      RealTimeTripUpdate.of(SCHEDULED_PATTERN, canceledTripTimes, TODAY)
+      RealTimeTripUpdate.of(SCHEDULED_PATTERN, canceledTripTimes.build(), TODAY)
         .withRevertPreviousRealTimeUpdates(true)
         .build()
     );
@@ -346,12 +349,11 @@ class TimetableSnapshotManagerTest {
   @Test
   void updateBufferDeleteScheduledTrip() {
     var manager = createManager();
-    var deletedTripTimes = SCHEDULED_TRIP_TIMES.createRealTimeFromScheduledTimes()
-      .deleteTrip()
-      .build();
+    var deletedTripTimes = SCHEDULED_TRIP_TIMES.createRealTimeFromScheduledTimes();
+    deletedTripTimes.realTimeMetadataBuilder().deleteTrip();
 
     manager.updateBuffer(
-      RealTimeTripUpdate.of(SCHEDULED_PATTERN, deletedTripTimes, TODAY)
+      RealTimeTripUpdate.of(SCHEDULED_PATTERN, deletedTripTimes.build(), TODAY)
         .withRevertPreviousRealTimeUpdates(true)
         .build()
     );
@@ -387,11 +389,10 @@ class TimetableSnapshotManagerTest {
     assertEquals(MODIFIED_PATTERN, manager.getNewTripPatternForModifiedTrip(TRIP.getId(), TODAY));
 
     // Now revert and cancel on the scheduled pattern
-    var canceledTripTimes = SCHEDULED_TRIP_TIMES.createRealTimeFromScheduledTimes()
-      .cancelTrip()
-      .build();
+    var canceledTripTimes = SCHEDULED_TRIP_TIMES.createRealTimeFromScheduledTimes();
+    canceledTripTimes.realTimeMetadataBuilder().cancelTrip();
     manager.updateBuffer(
-      RealTimeTripUpdate.of(SCHEDULED_PATTERN, canceledTripTimes, TODAY)
+      RealTimeTripUpdate.of(SCHEDULED_PATTERN, canceledTripTimes.build(), TODAY)
         .withRevertPreviousRealTimeUpdates(true)
         .build()
     );

--- a/application/src/test/java/org/opentripplanner/updater/trip/gtfs/BackwardsDelayAlwaysInterpolatorTest.java
+++ b/application/src/test/java/org/opentripplanner/updater/trip/gtfs/BackwardsDelayAlwaysInterpolatorTest.java
@@ -106,10 +106,16 @@ class BackwardsDelayAlwaysInterpolatorTest {
     );
     assertEquals(realTimeTime, builder.getArrivalTime(0));
     assertEquals(realTimeTime, builder.getDepartureTime(0));
-    assertEquals(StopRealTimeState.DEFAULT, builder.getStopRealTimeState(0));
+    assertEquals(
+      StopRealTimeState.DEFAULT,
+      builder.realTimeMetadataBuilder().getStopRealTimeState(0)
+    );
     assertNull(builder.getArrivalTime(1));
     assertNull(builder.getDepartureTime(1));
-    assertEquals(StopRealTimeState.DEFAULT, builder.getStopRealTimeState(1));
+    assertEquals(
+      StopRealTimeState.DEFAULT,
+      builder.realTimeMetadataBuilder().getStopRealTimeState(1)
+    );
   }
 
   @Test

--- a/application/src/test/java/org/opentripplanner/updater/trip/gtfs/BackwardsDelayRequiredInterpolatorTest.java
+++ b/application/src/test/java/org/opentripplanner/updater/trip/gtfs/BackwardsDelayRequiredInterpolatorTest.java
@@ -55,13 +55,19 @@ class BackwardsDelayRequiredInterpolatorTest {
     for (var i = 0; i < firstUpdateIndex; ++i) {
       assertEquals(0, builder.getArrivalDelay(i));
       assertEquals(0, builder.getDepartureDelay(i));
-      assertEquals(StopRealTimeState.DEFAULT, builder.getStopRealTimeState(i));
+      assertEquals(
+        StopRealTimeState.DEFAULT,
+        builder.realTimeMetadataBuilder().getStopRealTimeState(i)
+      );
     }
     // nothing after the first given update should be touched
     for (var i = firstUpdateIndex; i < STOP_COUNT; i++) {
       assertEquals(reference.getArrivalDelay(i), builder.getArrivalDelay(i));
       assertEquals(reference.getDepartureDelay(i), builder.getDepartureDelay(i));
-      assertEquals(StopRealTimeState.DEFAULT, builder.getStopRealTimeState(i));
+      assertEquals(
+        StopRealTimeState.DEFAULT,
+        builder.realTimeMetadataBuilder().getStopRealTimeState(i)
+      );
     }
   }
 
@@ -85,13 +91,19 @@ class BackwardsDelayRequiredInterpolatorTest {
     for (var i = 0; i < firstUpdateIndex; ++i) {
       assertEquals(0, builder.getArrivalDelay(i));
       assertEquals(0, builder.getDepartureDelay(i));
-      assertEquals(StopRealTimeState.NO_DATA, builder.getStopRealTimeState(i));
+      assertEquals(
+        StopRealTimeState.NO_DATA,
+        builder.realTimeMetadataBuilder().getStopRealTimeState(i)
+      );
     }
     // nothing after the first given update should be touched
     for (var i = firstUpdateIndex; i < STOP_COUNT; i++) {
       assertEquals(reference.getArrivalDelay(i), builder.getArrivalDelay(i));
       assertEquals(reference.getDepartureDelay(i), builder.getDepartureDelay(i));
-      assertEquals(StopRealTimeState.DEFAULT, builder.getStopRealTimeState(i));
+      assertEquals(
+        StopRealTimeState.DEFAULT,
+        builder.realTimeMetadataBuilder().getStopRealTimeState(i)
+      );
     }
   }
 
@@ -100,9 +112,11 @@ class BackwardsDelayRequiredInterpolatorTest {
     var firstUpdateIndex = 2;
     var canceledIndex = 1;
     var delay = 3;
-    var builder = SCHEDULED_TRIP_TIMES.createRealTimeWithoutScheduledTimes()
-      .withArrivalDelay(firstUpdateIndex, delay)
-      .withCanceled(canceledIndex);
+    var builder = SCHEDULED_TRIP_TIMES.createRealTimeWithoutScheduledTimes().withArrivalDelay(
+      firstUpdateIndex,
+      delay
+    );
+    builder.realTimeMetadataBuilder().withCanceled(canceledIndex);
     assertEquals(
       OptionalInt.of(firstUpdateIndex),
       new BackwardsDelayRequiredInterpolator(true).propagateBackwards(builder)
@@ -114,7 +128,7 @@ class BackwardsDelayRequiredInterpolatorTest {
       assertEquals(0, builder.getDepartureDelay(i));
       assertEquals(
         i == canceledIndex ? StopRealTimeState.CANCELLED : StopRealTimeState.NO_DATA,
-        builder.getStopRealTimeState(i)
+        builder.realTimeMetadataBuilder().getStopRealTimeState(i)
       );
     }
   }
@@ -134,13 +148,22 @@ class BackwardsDelayRequiredInterpolatorTest {
     );
     assertEquals(0, builder.getArrivalTime(0));
     assertEquals(0, builder.getDepartureTime(0));
-    assertEquals(StopRealTimeState.NO_DATA, builder.getStopRealTimeState(0));
+    assertEquals(
+      StopRealTimeState.NO_DATA,
+      builder.realTimeMetadataBuilder().getStopRealTimeState(0)
+    );
     assertEquals(150, builder.getArrivalTime(1));
     assertEquals(150, builder.getDepartureTime(1));
-    assertEquals(StopRealTimeState.NO_DATA, builder.getStopRealTimeState(1));
+    assertEquals(
+      StopRealTimeState.NO_DATA,
+      builder.realTimeMetadataBuilder().getStopRealTimeState(1)
+    );
     assertEquals(150, builder.getArrivalTime(2));
     assertNull(builder.getDepartureTime(2));
-    assertEquals(StopRealTimeState.DEFAULT, builder.getStopRealTimeState(2));
+    assertEquals(
+      StopRealTimeState.DEFAULT,
+      builder.realTimeMetadataBuilder().getStopRealTimeState(2)
+    );
   }
 
   @Test
@@ -163,17 +186,26 @@ class BackwardsDelayRequiredInterpolatorTest {
     for (var i = 0; i < firstUpdateIndex; ++i) {
       assertEquals(0, builder.getArrivalDelay(i));
       assertEquals(0, builder.getDepartureDelay(i));
-      assertEquals(StopRealTimeState.NO_DATA, builder.getStopRealTimeState(i));
+      assertEquals(
+        StopRealTimeState.NO_DATA,
+        builder.realTimeMetadataBuilder().getStopRealTimeState(i)
+      );
     }
     // the arrival should be fill in as well
     assertEquals(0, builder.getArrivalDelay(firstUpdateIndex));
     // TODO: It is not possible to specify NO_DATA just for the arrival yet
-    assertEquals(StopRealTimeState.DEFAULT, builder.getStopRealTimeState(firstUpdateIndex));
+    assertEquals(
+      StopRealTimeState.DEFAULT,
+      builder.realTimeMetadataBuilder().getStopRealTimeState(firstUpdateIndex)
+    );
     // nothing after the first given update should be touched
     for (var i = firstUpdateIndex + 1; i < STOP_COUNT; i++) {
       assertEquals(reference.getArrivalDelay(i), builder.getArrivalDelay(i));
       assertEquals(reference.getDepartureDelay(i), builder.getDepartureDelay(i));
-      assertEquals(StopRealTimeState.DEFAULT, builder.getStopRealTimeState(i));
+      assertEquals(
+        StopRealTimeState.DEFAULT,
+        builder.realTimeMetadataBuilder().getStopRealTimeState(i)
+      );
     }
   }
 
@@ -189,10 +221,16 @@ class BackwardsDelayRequiredInterpolatorTest {
     );
     assertEquals(SCHEDULED_TRIP_TIMES.getScheduledArrivalTime(0), builder.getArrivalTime(0));
     assertEquals(10, builder.getDepartureTime(0));
-    assertEquals(StopRealTimeState.DEFAULT, builder.getStopRealTimeState(0));
+    assertEquals(
+      StopRealTimeState.DEFAULT,
+      builder.realTimeMetadataBuilder().getStopRealTimeState(0)
+    );
     assertNull(builder.getArrivalTime(1));
     assertNull(builder.getDepartureTime(1));
-    assertEquals(StopRealTimeState.DEFAULT, builder.getStopRealTimeState(1));
+    assertEquals(
+      StopRealTimeState.DEFAULT,
+      builder.realTimeMetadataBuilder().getStopRealTimeState(1)
+    );
   }
 
   @Test
@@ -212,10 +250,16 @@ class BackwardsDelayRequiredInterpolatorTest {
     );
     assertEquals(realTimeTime, builder.getArrivalTime(0));
     assertEquals(realTimeTime, builder.getDepartureTime(0));
-    assertEquals(StopRealTimeState.DEFAULT, builder.getStopRealTimeState(0));
+    assertEquals(
+      StopRealTimeState.DEFAULT,
+      builder.realTimeMetadataBuilder().getStopRealTimeState(0)
+    );
     assertNull(builder.getArrivalTime(1));
     assertNull(builder.getDepartureTime(1));
-    assertEquals(StopRealTimeState.DEFAULT, builder.getStopRealTimeState(1));
+    assertEquals(
+      StopRealTimeState.DEFAULT,
+      builder.realTimeMetadataBuilder().getStopRealTimeState(1)
+    );
   }
 
   @Test

--- a/application/src/test/java/org/opentripplanner/updater/trip/gtfs/DefaultForwardsDelayInterpolatorTest.java
+++ b/application/src/test/java/org/opentripplanner/updater/trip/gtfs/DefaultForwardsDelayInterpolatorTest.java
@@ -78,7 +78,7 @@ class DefaultForwardsDelayInterpolatorTest {
     var builder = SCHEDULED_TRIP_TIMES.createRealTimeWithoutScheduledTimes();
     builder.withArrivalDelay(3, 300);
     builder.withArrivalDelay(8, 60);
-    builder.withNoData(10);
+    builder.realTimeMetadataBuilder().withNoData(10);
     assertTrue(new DefaultForwardsDelayInterpolator().interpolateDelay(builder));
     // stops 0 to 2 are handled by the backwards propagator, which is outside the scope of the test
     for (var i = 3; i < 8; ++i) {
@@ -93,7 +93,7 @@ class DefaultForwardsDelayInterpolatorTest {
       // for NO_DATA stop, we assume that they run as scheduled in the internal model
       assertEquals(0, builder.getArrivalDelay(i));
       assertEquals(0, builder.getDepartureDelay(i));
-      assertEquals(NO_DATA, builder.getStopRealTimeState(i));
+      assertEquals(NO_DATA, builder.realTimeMetadataBuilder().getStopRealTimeState(i));
     }
     // we need to propagate backwards from stop 3 before building
     assertEquals(
@@ -123,7 +123,7 @@ class DefaultForwardsDelayInterpolatorTest {
     var builder = SCHEDULED_TRIP_TIMES.createRealTimeWithoutScheduledTimes();
     builder.withArrivalDelay(0, 450);
     builder.withDepartureDelay(0, 450);
-    builder.withNoData(1);
+    builder.realTimeMetadataBuilder().withNoData(1);
     assertTrue(new DefaultForwardsDelayInterpolator().interpolateDelay(builder));
     // for stop 1, the scheduled time is earlier than the delayed departure at stop 0
     assertNotEquals(0, builder.getArrivalDelay(1));
@@ -148,7 +148,7 @@ class DefaultForwardsDelayInterpolatorTest {
     ).createRealTimeWithoutScheduledTimes();
     builder.withArrivalDelay(0, 450);
     builder.withDepartureDelay(0, 450);
-    builder.withNoData(1);
+    builder.realTimeMetadataBuilder().withNoData(1);
     assertTrue(new DefaultForwardsDelayInterpolator().interpolateDelay(builder));
     // for stop 1, the scheduled arrival time is earlier than the delayed departure at stop 0
     assertNotEquals(0, builder.getArrivalDelay(1));
@@ -160,22 +160,28 @@ class DefaultForwardsDelayInterpolatorTest {
 
   @Test
   void noRealTimeIsProvided() {
-    var builder = SCHEDULED_TRIP_TIMES.createRealTimeWithoutScheduledTimes()
-      .withCanceled(5)
-      .withInaccuratePredictions(7);
+    var builder = SCHEDULED_TRIP_TIMES.createRealTimeWithoutScheduledTimes();
+    builder.realTimeMetadataBuilder().withCanceled(5);
+    builder.realTimeMetadataBuilder().withInaccuratePredictions(7);
     assertTrue(new DefaultForwardsDelayInterpolator().interpolateDelay(builder));
     for (var i = 0; i < STOP_COUNT; ++i) {
       assertEquals(0, builder.getArrivalDelay(i));
       assertEquals(0, builder.getDepartureDelay(i));
     }
     for (var i = 0; i < 5; ++i) {
-      assertEquals(DEFAULT, builder.getStopRealTimeState(i));
+      assertEquals(DEFAULT, builder.realTimeMetadataBuilder().getStopRealTimeState(i));
     }
-    assertEquals(StopRealTimeState.CANCELLED, builder.getStopRealTimeState(5));
+    assertEquals(
+      StopRealTimeState.CANCELLED,
+      builder.realTimeMetadataBuilder().getStopRealTimeState(5)
+    );
     // SKIPPED stop does not propagate
-    assertEquals(DEFAULT, builder.getStopRealTimeState(6));
+    assertEquals(DEFAULT, builder.realTimeMetadataBuilder().getStopRealTimeState(6));
     for (var i = 7; i < STOP_COUNT; ++i) {
-      assertEquals(StopRealTimeState.INACCURATE_PREDICTIONS, builder.getStopRealTimeState(i));
+      assertEquals(
+        StopRealTimeState.INACCURATE_PREDICTIONS,
+        builder.realTimeMetadataBuilder().getStopRealTimeState(i)
+      );
     }
     builder.build();
   }
@@ -183,7 +189,9 @@ class DefaultForwardsDelayInterpolatorTest {
   @Test
   void noDataOnly() {
     var interpolator = new DefaultForwardsDelayInterpolator();
-    var builder = SCHEDULED_TRIP_TIMES.createRealTimeWithoutScheduledTimes()
+    var builder = SCHEDULED_TRIP_TIMES.createRealTimeWithoutScheduledTimes();
+    builder
+      .realTimeMetadataBuilder()
       .withNoData(0)
       .withNoData(1)
       .withNoData(2)
@@ -198,7 +206,7 @@ class DefaultForwardsDelayInterpolatorTest {
       .forEach(i -> {
         assertEquals(0, builder.getArrivalDelay(i));
         assertEquals(0, builder.getDepartureDelay(i));
-        assertEquals(NO_DATA, builder.getStopRealTimeState(i));
+        assertEquals(NO_DATA, builder.realTimeMetadataBuilder().getStopRealTimeState(i));
       });
     assertNotNull(builder.build());
   }
@@ -207,6 +215,10 @@ class DefaultForwardsDelayInterpolatorTest {
   void canceledStops() {
     // Stops 4 to 10 takes 1800 seconds scheduled, 900 seconds actual
     var builder = SCHEDULED_TRIP_TIMES.createRealTimeWithoutScheduledTimes()
+      .withArrivalTime(3, 3000)
+      .withArrivalTime(10, 4200);
+    builder
+      .realTimeMetadataBuilder()
       .withCanceled(0)
       .withCanceled(1)
       .withCanceled(2)
@@ -216,9 +228,8 @@ class DefaultForwardsDelayInterpolatorTest {
       .withCanceled(8)
       .withCanceled(9)
       .withCanceled(18)
-      .withCanceled(19)
-      .withArrivalTime(3, 3000)
-      .withArrivalTime(10, 4200);
+      .withCanceled(19);
+
     assertTrue(new DefaultForwardsDelayInterpolator().interpolateDelay(builder));
     // 0 to 2 should not be touched at all, it is the job for the backward interpolator
     assertNull(builder.getDepartureTime(0));

--- a/application/src/test/java/org/opentripplanner/updater/trip/gtfs/NoDataBackwardsEarlinessInterpolatorTest.java
+++ b/application/src/test/java/org/opentripplanner/updater/trip/gtfs/NoDataBackwardsEarlinessInterpolatorTest.java
@@ -8,11 +8,13 @@ import static org.opentripplanner.transit.model.timetable.StopRealTimeState.DEFA
 import static org.opentripplanner.transit.model.timetable.StopRealTimeState.NO_DATA;
 
 import java.util.List;
+import java.util.stream.IntStream;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.opentripplanner.core.framework.deduplicator.DeduplicatorService;
 import org.opentripplanner.transit.model._data.TimetableRepositoryForTest;
 import org.opentripplanner.transit.model.timetable.ScheduledTripTimes;
+import org.opentripplanner.transit.model.timetable.StopRealTimeState;
 import org.opentripplanner.transit.model.timetable.Trip;
 import org.opentripplanner.transit.model.timetable.TripTimesFactory;
 import org.opentripplanner.utils.collection.ListUtils;
@@ -39,23 +41,21 @@ class NoDataBackwardsEarlinessInterpolatorTest {
   @MethodSource("requiredInterpolators")
   void precedingNoDataWithEarlyArrival(BackwardsDelayInterpolator interpolator) {
     var builder = SCHEDULED_TRIP_TIMES.createRealTimeWithoutScheduledTimes()
-      .withNoData(0)
-      .withNoData(1)
-      .withNoData(2)
       .withArrivalDelay(3, SIX_MINUTES_EARLY)
       .withDepartureDelay(3, SIX_MINUTES_EARLY)
       .withArrivalDelay(4, SIX_MINUTES_EARLY)
       .withDepartureDelay(4, SIX_MINUTES_EARLY);
+    builder.realTimeMetadataBuilder().withNoData(0).withNoData(1).withNoData(2);
 
     assertThat(interpolator.propagateBackwards(builder)).hasValue(3);
 
     assertEquals(-60, builder.getArrivalDelay(2));
     assertEquals(-60, builder.getDepartureDelay(2));
-    assertEquals(NO_DATA, builder.getStopRealTimeState(2));
+    assertEquals(NO_DATA, builder.realTimeMetadataBuilder().getStopRealTimeState(2));
     List.of(0, 1).forEach(i -> {
       assertEquals(0, builder.getArrivalDelay(i));
       assertEquals(0, builder.getDepartureDelay(i));
-      assertEquals(NO_DATA, builder.getStopRealTimeState(i));
+      assertEquals(NO_DATA, builder.realTimeMetadataBuilder().getStopRealTimeState(i));
     });
 
     assertNotNull(builder.build());
@@ -72,22 +72,20 @@ class NoDataBackwardsEarlinessInterpolatorTest {
   @MethodSource("allInterpolators")
   void leadingNoDataAndCancelledWithEarlyArrival(BackwardsDelayInterpolator interpolator) {
     var builder = SCHEDULED_TRIP_TIMES.createRealTimeWithoutScheduledTimes()
-      .withNoData(0)
-      .withCanceled(1)
-      .withNoData(2)
       .withArrivalDelay(3, SIX_MINUTES_EARLY)
       .withDepartureDelay(3, SIX_MINUTES_EARLY)
       .withArrivalDelay(4, SIX_MINUTES_EARLY)
       .withDepartureDelay(4, SIX_MINUTES_EARLY);
+    builder.realTimeMetadataBuilder().withNoData(0).withCanceled(1).withNoData(2);
 
     assertThat(interpolator.propagateBackwards(builder)).hasValue(3);
 
-    assertEquals(NO_DATA, builder.getStopRealTimeState(2));
+    assertEquals(NO_DATA, builder.realTimeMetadataBuilder().getStopRealTimeState(2));
 
-    assertThat(builder.stopRealTimeStates())
-      .asList()
-      .containsExactly(NO_DATA, CANCELLED, NO_DATA, DEFAULT, DEFAULT);
-
+    List<StopRealTimeState> stopRealTimeStates = IntStream.range(0, STOP_COUNT)
+      .mapToObj(i -> builder.realTimeMetadataBuilder().getStopRealTimeState(i))
+      .toList();
+    assertThat(stopRealTimeStates).containsExactly(NO_DATA, CANCELLED, NO_DATA, DEFAULT, DEFAULT);
     assertNotNull(builder.build());
   }
 }

--- a/application/src/test/java/org/opentripplanner/updater/trip/siri/TimetableHelperTest.java
+++ b/application/src/test/java/org/opentripplanner/updater/trip/siri/TimetableHelperTest.java
@@ -26,6 +26,11 @@ import org.opentripplanner.transit.service.SiteRepository;
 import uk.org.siri.siri21.CallStatusEnumeration;
 import uk.org.siri.siri21.OccupancyEnumeration;
 
+/**
+ * Tests TimetableHelper (timing, headsigns, extra calls, arrived/departed) together with
+ * RealTimeInfoUpdater (occupancy, cancellation, prediction inaccuracy) since both are called
+ * in sequence by the trip builders.
+ */
 public class TimetableHelperTest {
 
   private static final String FEED_ID = "FEED_ID";
@@ -89,7 +94,7 @@ public class TimetableHelperTest {
       .withPredictionInaccurate(true)
       .build();
 
-    TimetableHelper.applyUpdates(START_OF_SERVICE, builder, 0, false, false, estimatedCall, null);
+    applyUpdatesAtStop(0, false, false, estimatedCall, null);
 
     assertEquals(
       "Occupancy:MANY_SEATS_AVAILABLE Cancelled:false Extra:false Arrived:false Departed:false Inaccurate:true",
@@ -106,7 +111,7 @@ public class TimetableHelperTest {
       .withPredictionInaccurate(true)
       .build();
 
-    TimetableHelper.applyUpdates(START_OF_SERVICE, builder, 0, false, false, estimatedCall, null);
+    applyUpdatesAtStop(0, false, false, estimatedCall, null);
 
     assertEquals(
       "Occupancy:FULL Cancelled:true Extra:false Arrived:false Departed:false Inaccurate:false",
@@ -125,7 +130,7 @@ public class TimetableHelperTest {
       .withActualDepartureTime(actualTime)
       .build();
 
-    TimetableHelper.applyUpdates(START_OF_SERVICE, builder, 0, false, false, recordedCall, null);
+    applyUpdatesAtStop(0, false, false, recordedCall, null);
 
     assertEquals(
       "Occupancy:FULL Cancelled:true Extra:false Arrived:false Departed:false Inaccurate:false",
@@ -143,7 +148,7 @@ public class TimetableHelperTest {
       .withActualDepartureTime(START_OF_SERVICE.plus(Duration.ofHours(1)))
       .build();
 
-    TimetableHelper.applyUpdates(START_OF_SERVICE, builder, 0, false, false, recordedCall, null);
+    applyUpdatesAtStop(0, false, false, recordedCall, null);
 
     assertEquals(
       "Occupancy:FULL Cancelled:false Extra:false Arrived:false Departed:false Inaccurate:true",
@@ -162,7 +167,7 @@ public class TimetableHelperTest {
       .withIsRecorded(true)
       .build();
 
-    TimetableHelper.applyUpdates(START_OF_SERVICE, builder, 0, false, false, recordedCall, null);
+    applyUpdatesAtStop(0, false, false, recordedCall, null);
 
     assertEquals(
       "Occupancy:STANDING_ROOM_ONLY Cancelled:false Extra:false Arrived:true Departed:true Inaccurate:false",
@@ -181,7 +186,7 @@ public class TimetableHelperTest {
       .withArrivalStatus(CallStatusEnumeration.ARRIVED)
       .build();
 
-    TimetableHelper.applyUpdates(START_OF_SERVICE, builder, 0, false, false, recordedCall, null);
+    applyUpdatesAtStop(0, false, false, recordedCall, null);
 
     assertEquals(
       "Occupancy:STANDING_ROOM_ONLY Cancelled:false Extra:false Arrived:true Departed:false Inaccurate:false",
@@ -193,15 +198,7 @@ public class TimetableHelperTest {
   public void testApplyUpdates_JourneyDefaultValues() {
     CallWrapper recordedCall = TestCall.of().withStopPointRef(STOP_ID).build();
 
-    TimetableHelper.applyUpdates(
-      START_OF_SERVICE,
-      builder,
-      0,
-      false,
-      true,
-      recordedCall,
-      OccupancyEnumeration.STANDING_AVAILABLE
-    );
+    applyUpdatesAtStop(0, false, true, recordedCall, OccupancyEnumeration.STANDING_AVAILABLE);
 
     assertEquals(
       "Occupancy:STANDING_ROOM_ONLY Cancelled:false Extra:false Arrived:false Departed:false Inaccurate:true",
@@ -222,7 +219,7 @@ public class TimetableHelperTest {
       .withIsRecorded(true)
       .build();
 
-    TimetableHelper.applyUpdates(START_OF_SERVICE, builder, 0, false, false, recordedCall, null);
+    applyUpdatesAtStop(0, false, false, recordedCall, null);
 
     assertEquals(
       "Occupancy:NO_DATA_AVAILABLE Cancelled:false Extra:false Arrived:true Departed:false Inaccurate:false",
@@ -234,11 +231,32 @@ public class TimetableHelperTest {
   public void testApplyUpdates_ExtraCall_EstimatedCall() {
     CallWrapper estimatedCall = TestCall.of().withExtraCall(true).build();
 
-    TimetableHelper.applyUpdates(START_OF_SERVICE, builder, 0, false, false, estimatedCall, null);
+    applyUpdatesAtStop(0, false, false, estimatedCall, null);
 
     assertEquals(
       "Occupancy:NO_DATA_AVAILABLE Cancelled:false Extra:true Arrived:false Departed:false Inaccurate:false",
       showStatuses(0)
+    );
+  }
+
+  /**
+   * Applies updates at a stop using both TimetableHelper and RealTimeInfoUpdater, mirroring the
+   * production call sequence in the trip builders.
+   */
+  private void applyUpdatesAtStop(
+    int stopIndex,
+    boolean isLastStop,
+    boolean isJourneyPredictionInaccurate,
+    CallWrapper call,
+    OccupancyEnumeration journeyOccupancy
+  ) {
+    TimetableHelper.applyUpdates(START_OF_SERVICE, builder, stopIndex, isLastStop, call);
+    SiriRealTimeMetadataHelper.updateRealTimeMetadataAtStop(
+      builder.realTimeMetadataBuilder(),
+      stopIndex,
+      call,
+      journeyOccupancy,
+      isJourneyPredictionInaccurate
     );
   }
 


### PR DESCRIPTION
## Summary

This refactoring aims to encapsulate mostly API relevant Metadata for the Realtime of a trip into its own class.

## Issue

We want to be able to store more Metadata for the Realtime of a trip, specifically we want to reset the realtime delays of a journey to the Scheduled times and show the client, that this journey no longer has realtime information. With this refactoring it will also be possible to store information such as a "lastUpdated" timestamp (which i have added in this Draft PR as an example). This information should be acessed without bloating the TripTimes Interface further. 

This is the first of at least 2 PRs to resolve issue #7513

### Worth discussing:
#### Exposing inner Builder vs. delegating
The `TripRealTimeMetadataBuilder` gets exposed through the `RealTimeTripTimesBuilder` (composite Builder). this makes interactions like setting the RealtimeState a little unintuitive, as the chaining of the builder gets broken. Another option might be to delegate from the outer Builder to the inner, that would cause bloating in the outer Builder.

## Unit Tests
- will be added after we have consensus on the actual implementation

## Documentation
- javadoc added for the new classes

## Next Steps
- when concept approved: finalize this PR (write tests, remove lastUpdated etc.)
- implement reset of journeys via SIRI-ET (either using existing Fields or by adding a new one) (new PR)
- Expose this information to the API (new PR)
 